### PR TITLE
implement optional support for Datastore REST API usage

### DIFF
--- a/gcredstash/config.py
+++ b/gcredstash/config.py
@@ -3,6 +3,7 @@ import os
 
 class Config(object):
     PROJECT_ID = os.environ.get('GCREDSTASH_GCP_PROJECT_ID')
+    KEYSTORE_REST_API = os.environ.get('GCREDSTASH_KEYSTORE_REST_API', '0').lower() in ['1', 't', 'true', 'y', 'yes']
     DEFAULT_KEY_RING_ID = os.environ.get('GCREDSTASH_DEFAULT_KEY_RING_ID')
     DEFAULT_LOCATION_ID = os.environ.get('GCREDSTASH_DEFAULT_LOCATION_ID') or "global"
     DEFAULT_CRYPTO_KEY_ID = os.environ.get('GCREDSTASH_DEFAULT_CRYPTO_KEY_ID')

--- a/gcredstash/keystore.py
+++ b/gcredstash/keystore.py
@@ -1,11 +1,101 @@
-from google.cloud import datastore
+import base64
+
+
+class RESTClient(object):
+    def __init__(self, creds, project_id):
+        self.creds = creds
+        self.project_id = project_id
+        self.url = 'https://datastore.googleapis.com/v1/projects/' + project_id
+
+    def _get_authed_session(self):
+        from google.auth.transport.requests import AuthorizedSession
+        return AuthorizedSession(self.creds)
+
+    def _make_request(self, method, url, data=None, headers=None, **kwargs):
+        authed_session = self._get_authed_session()
+        return authed_session.request(method, url, data, headers, **kwargs)
+
+    def _yield_key_part(self, key):
+        for i in xrange(0, len(key), 2):
+            yield key[i:i + 2]
+
+    def key(self, *args):
+        return args
+
+    def get(self, key):
+        if not key or len(key) % 2 != 0:
+            raise ValueError('You must specify a valid datastore key')
+
+        path = []
+        for part in self._yield_key_part(key):
+            path.append({
+                'kind': part[0],
+                'name': part[-1]
+            })
+
+        r = self._make_request('POST', self.url + ':lookup', json={
+            'keys': [{
+                'path': path
+            }]
+        })
+        r.raise_for_status()
+
+        result = r.json().get('found', [{}])
+        assert len(result) == 1
+        return result[0].get('entity', {}).get('properties')
+
+    def put(self, entity):
+        if not entity or not isinstance(entity, dict):
+            raise ValueError('You must specify entity dict')
+
+        r = self._make_request('POST', self.url + ':commit', json={
+            'mutations': [{
+                'upsert': entity
+            }],
+            'mode': 'NON_TRANSACTIONAL'
+        })
+        r.raise_for_status()
+
+    def query(self, kind):
+        class Struct(object):
+            def __init__(self, **entries):
+                self.__dict__.update(entries)
+
+        r = self._make_request('POST', self.url + ':runQuery', json={
+            'query': {
+                'kind': [{
+                    'name': kind
+                }]
+            }
+        })
+        r.raise_for_status()
+
+        results = r.json().get('batch', {}).get('entityResults', [])
+
+        def fetch():
+            for result in results:
+                name = result.get('entity', {}).get('key', {}).get('path', [{}])[0].get('name')
+                yield Struct(**{'key': Struct(**{'name': name})})
+
+        r.fetch = fetch
+        return r
 
 
 class KeyStore(object):
     CIPHER_PROPERTY_KEY = 'cipher'
 
-    def __init__(self, project_id=None, namespace=None):
-        self.client = datastore.Client(project=project_id, namespace=namespace)
+    def __init__(self, project_id=None, namespace=None, rest_api=False):
+        self.rest_api = rest_api
+        if rest_api:
+            import google.auth
+            scopes = [
+                'https://www.googleapis.com/auth/datastore'
+            ]
+            creds, project_id = google.auth.default(scopes)
+            self.client = RESTClient(creds, project_id)
+        else:
+            from google.cloud import datastore
+            self.client = datastore.Client(project=project_id, namespace=namespace)
 
     def get(self, kind, name):
         """
@@ -19,7 +109,8 @@ class KeyStore(object):
         entity = self.client.get(key)
         if not entity:
             return None
-
+        elif self.rest_api:
+            return base64.b64decode(entity.get(KeyStore.CIPHER_PROPERTY_KEY).get('blobValue'))
         return entity.get(KeyStore.CIPHER_PROPERTY_KEY)
 
     def put(self, kind, name, content):
@@ -30,9 +121,26 @@ class KeyStore(object):
         :param content: value to store
         :return:
         """
-        key = self.client.key(kind, name)
-        entity = datastore.Entity(key=key, exclude_from_indexes=(KeyStore.CIPHER_PROPERTY_KEY,))
-        entity[KeyStore.CIPHER_PROPERTY_KEY] = content
+        if self.rest_api:
+            entity = {
+                'key': {
+                    'path': [{
+                        'kind': kind,
+                        'name': name
+                    }]
+                },
+                'properties': {
+                    KeyStore.CIPHER_PROPERTY_KEY: {
+                        'excludeFromIndexes': True,
+                        'blobValue': base64.b64encode(content)
+                    }
+                }
+            }
+        else:
+            from google.cloud import datastore
+            key = self.client.key(kind, name)
+            entity = datastore.Entity(key=key, exclude_from_indexes=(KeyStore.CIPHER_PROPERTY_KEY,))
+            entity[KeyStore.CIPHER_PROPERTY_KEY] = content
         return self.client.put(entity)
 
     def list(self, kind):

--- a/gcredstash/main.py
+++ b/gcredstash/main.py
@@ -35,6 +35,11 @@ parser.add_argument(
     '--project-id',
     default=Config.PROJECT_ID, dest='project_id', type=str, help='GCP Project Id')
 parser.add_argument(
+    '--keystore-rest-api',
+    default=Config.KEYSTORE_REST_API, dest='keystore_rest_api', action='store_true',
+    help='Uses Datastore REST API (Useful for GAE Standard environment)'
+)
+parser.add_argument(
     '--location-id',
     default=Config.DEFAULT_LOCATION_ID, dest='location_id', type=str, help='Google Cloud KMS Location Id')
 parser.add_argument(
@@ -47,7 +52,7 @@ parser.add_argument(
 
 def main():
     args = parser.parse_args()
-    key_store = KeyStore(args.project_id)
+    key_store = KeyStore(args.project_id, rest_api=args.keystore_rest_api)
     kms_client = googleapiclient.discovery.build('cloudkms', 'v1')
     kms = GoogleKMS(kms_client, args.project_id, args.location_id, args.key_ring_id, key_store)
 


### PR DESCRIPTION
Hello!

This PR allows optional usage of the Datastore REST API. We found the need to implement this so we could migrate from the GAE Flexible environment to the Standard environment. The issue is in importing google.cloud.datastore which this PR prevents from being imported if KeyStore is initialized with rest_api=True. 

Usage: 
```python
keystore = KeyStore(project_id, rest_api=True)
```
```console
foo@bar:~$ gcredstash --keystore-rest-api get SOME_KEY
```